### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://yrp.visualstudio.com/cc16245b-87ea-4a67-b923-a4733039a853/4fa64512-70c3-4952-aed1-8062b99c5857/_apis/work/boardbadge/210226b5-99ee-4c8d-b316-e3b77013655c)](https://yrp.visualstudio.com/cc16245b-87ea-4a67-b923-a4733039a853/_boards/board/t/4fa64512-70c3-4952-aed1-8062b99c5857/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#794](https://yrp.visualstudio.com/cc16245b-87ea-4a67-b923-a4733039a853/_workitems/edit/794). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.